### PR TITLE
Feat/issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,5 +107,5 @@ typings/
 package-lock.json
 yarn.lock
 
-test/local-config.js
+test/local-config-template.js
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ seneca.use('GithubProvider', { name: value, ... })
 
 ## Action Patterns
 
+* [role:entity,base:github,cmd:load,name:issue,zone:provider](#-roleentitybasegithubcmdloadnameissuezoneprovider-)
 * [role:entity,base:github,cmd:load,name:repo,zone:provider](#-roleentitybasegithubcmdloadnamerepozoneprovider-)
 * [role:entity,base:github,cmd:save,name:repo,zone:provider](#-roleentitybasegithubcmdsavenamerepozoneprovider-)
 * [sys:provider,get:info,provider:github](#-sysprovidergetinfoprovidergithub-)
@@ -103,6 +104,13 @@ seneca.use('GithubProvider', { name: value, ... })
 
 ## Action Descriptions
 
+### &laquo; `role:entity,base:github,cmd:load,name:issue,zone:provider` &raquo;
+
+Load GitHub Issue data into an entity.
+
+
+
+----------
 ### &laquo; `role:entity,base:github,cmd:load,name:repo,zone:provider` &raquo;
 
 Load GitHub repository data into an entity.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ seneca.use('GithubProvider', { name: value, ... })
 
 * [role:entity,base:github,cmd:load,name:issue,zone:provider](#-roleentitybasegithubcmdloadnameissuezoneprovider-)
 * [role:entity,base:github,cmd:load,name:repo,zone:provider](#-roleentitybasegithubcmdloadnamerepozoneprovider-)
+* [role:entity,base:github,cmd:save,name:issue,zone:provider](#-roleentitybasegithubcmdsavenameissuezoneprovider-)
 * [role:entity,base:github,cmd:save,name:repo,zone:provider](#-roleentitybasegithubcmdsavenamerepozoneprovider-)
 * [sys:provider,get:info,provider:github](#-sysprovidergetinfoprovidergithub-)
 
@@ -114,6 +115,13 @@ Load GitHub Issue data into an entity.
 ### &laquo; `role:entity,base:github,cmd:load,name:repo,zone:provider` &raquo;
 
 Load GitHub repository data into an entity.
+
+
+
+----------
+### &laquo; `role:entity,base:github,cmd:save,name:issue,zone:provider` &raquo;
+
+Update GitHub Issue data from an entity.
 
 
 

--- a/src/GithubProvider-doc.ts
+++ b/src/GithubProvider-doc.ts
@@ -1,12 +1,6 @@
 /* Copyright © 2021 Seneca Project Contributors, MIT License. */
 
-
-const docs = {
-
-  get_info: {
-    desc: 'Get information about the provider.',
-  },
-
+const repo_docs = {
   load_repo: {
     desc: 'Load GitHub repository data into an entity.',
   },
@@ -14,10 +8,24 @@ const docs = {
   save_repo: {
     desc: 'Update GitHub repository data from an entity.',
   },
+}
+
+const issue_docs = {
+  save_issue: {
+    desc: 'Update GitHub Issue data from an entity.',
+  },
 
   load_issue: {
     desc: 'Load GitHub Issue data into an entity.',
   },
+}
+
+const docs = {
+  get_info: {
+    desc: 'Get information about the provider.',
+  },
+  ...repo_docs,
+  ...issue_docs,
 }
 
 export default docs

--- a/src/GithubProvider-doc.ts
+++ b/src/GithubProvider-doc.ts
@@ -15,6 +15,9 @@ const docs = {
     desc: 'Update GitHub repository data from an entity.',
   },
 
+  load_issue: {
+    desc: 'Load GitHub Issue data into an entity.',
+  },
 }
 
 export default docs

--- a/src/entities/issue.ts
+++ b/src/entities/issue.ts
@@ -22,7 +22,34 @@ function issue(args: InitialCommandsArgs) {
   }
 
   async function save_issue(this: any, msg: any) {
+    const ent: any = msg.ent
+    const repo_id = ent.repo_id
+    const issue_number = ent.issue_number
 
+    const [owner, repo]: [string, string] = repo_id.split("/")
+
+    const data = {
+      owner,
+      repo,
+      issue_number,
+
+      title: ent.title,
+      body: ent.body,
+      assignee: null, // attribute deprecated according to documentation
+      state: ent.state,
+      milestone: ent.milestone,
+      labels: ent.labels,
+      assigness: ent.assigness,
+    }
+
+    const res = await args.octokit.rest.issues.update(data)
+
+    const issue: any = res.data
+
+    issue.repo_id = repo_id
+    issue.issue_number = issue_number
+
+    return this.make$(args.ZONE_BASE + "issue").data$(issue)
   }
 
   return {

--- a/src/entities/issue.ts
+++ b/src/entities/issue.ts
@@ -1,4 +1,6 @@
-function issues(args: any) {
+import { InitialCommandsArgs } from "../types"
+
+function issue(args: InitialCommandsArgs) {
   async function load_issue(this: any, msg: any) {
     const repo_id = msg.q.repo_id
     const issue_number = msg.q.issue_number
@@ -29,4 +31,4 @@ function issues(args: any) {
   }
 }
 
-export default issues
+export default issue

--- a/src/entities/issues.ts
+++ b/src/entities/issues.ts
@@ -1,6 +1,22 @@
 function issues(args: any) {
   async function load_issue(this: any, msg: any) {
+    const repo_id = msg.q.id
+    const issue_number = msg.q.issue_number
 
+    const [ownername, reponame]: [string, string] = repo_id.split("/")
+
+    const res = await args.octokit.rest.issues.get({
+      owner: ownername,
+      repo: reponame,
+      issue_number,
+    })
+
+    const issue: any = res.data
+
+    issue.repo_id = repo_id
+    issue.issue_number = issue_number
+
+    return this.make$(args.ZONE_BASE + "issue").data$(issue)
   }
 
   async function save_issue(this: any, msg: any) {

--- a/src/entities/issues.ts
+++ b/src/entities/issues.ts
@@ -1,6 +1,6 @@
 function issues(args: any) {
   async function load_issue(this: any, msg: any) {
-    const repo_id = msg.q.id
+    const repo_id = msg.q.repo_id
     const issue_number = msg.q.issue_number
 
     const [ownername, reponame]: [string, string] = repo_id.split("/")

--- a/src/entities/issues.ts
+++ b/src/entities/issues.ts
@@ -1,0 +1,16 @@
+function issues(args: any) {
+  async function load_issue(this: any, msg: any) {
+
+  }
+
+  async function save_issue(this: any, msg: any) {
+
+  }
+
+  return {
+    load_issue,
+    save_issue,
+  }
+}
+
+export default issues

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -24,21 +24,21 @@ function GithubProvider(this: any, _options: any) {
 
   let octokit: Octokit
 
-  const initalArgs: any = {
+  const commom_args: any = {
     ZONE_BASE,
     octokit: undefined
   }
 
   /**
    * Passes initial arguments to the closure of each command group
-   * @param CommandsCb callback
+   * @param commandsCb callback
    * @returns {Object} object containing all commands of a entity 
    */
-  function initCmds(CommandsCb: any) {
-    return CommandsCb(initalArgs)
+  function init_commands(commandsCb: any) {
+    return commandsCb(commom_args)
   }
 
-  const issuesCmds = initCmds(issues)
+  const issues_cmds = init_commands(issues)
 
   // NOTE: sys- zone prefix is reserved.
 
@@ -50,7 +50,7 @@ function GithubProvider(this: any, _options: any) {
     .message('role:entity,cmd:save,zone:provider,base:github,name:repo',
       save_repo)
 
-    .message('role:entity,cmd:load,zone:provider,base:github,name:issue', issuesCmds.load_issue)
+    .message('role:entity,cmd:load,zone:provider,base:github,name:issue', issues_cmds.load_issue)
 
   async function get_info(this: any, _msg: any) {
     return {
@@ -121,8 +121,8 @@ function GithubProvider(this: any, _options: any) {
 
     octokit = new Octokit(config)
 
-    initalArgs.octokit = octokit
-    Object.freeze(initalArgs)
+    commom_args.octokit = octokit
+    Object.freeze(commom_args)
   })
 
 

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -23,6 +23,19 @@ function GithubProvider(this: any, _options: any) {
 
   let octokit: Octokit
 
+  const initalArgs: any = {
+    ZONE_BASE,
+    octokit: undefined
+  }
+
+  /**
+   * Passes initial arguments to the closure of each command group
+   * @param CommandsCb callback
+   * @returns {Object} object containing all commands of a entity 
+   */
+  function initCmds(CommandsCb: any) {
+    return CommandsCb(initalArgs)
+  }
 
   // NOTE: sys- zone prefix is reserved.
 

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -50,7 +50,7 @@ function GithubProvider(this: any, _options: any) {
     .message('role:entity,cmd:save,zone:provider,base:github,name:repo',
       save_repo)
 
-
+    .message('role:entity,cmd:load,zone:provider,base:github,name:issue', issuesCmds.load_issue)
 
   async function get_info(this: any, _msg: any) {
     return {

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -4,7 +4,7 @@
 // TODO: namespace provider zone; needs seneca-entity feature
 
 import { Octokit } from '@octokit/rest'
-import issues from './entities/issues'
+import init_commands from './init-commands'
 
 
 type GithubProviderOptions = {}
@@ -24,21 +24,12 @@ function GithubProvider(this: any, _options: any) {
 
   let octokit: Octokit
 
-  const commom_args: any = {
+  const initial_args: any = {
     ZONE_BASE,
     octokit: undefined
   }
 
-  /**
-   * Passes initial arguments to the closure of each command group
-   * @param commandsCb callback
-   * @returns {Object} object containing all commands of a entity 
-   */
-  function init_commands(commandsCb: any) {
-    return commandsCb(commom_args)
-  }
-
-  const issues_cmds = init_commands(issues)
+  const commands = init_commands(initial_args)
 
   // NOTE: sys- zone prefix is reserved.
 
@@ -50,7 +41,7 @@ function GithubProvider(this: any, _options: any) {
     .message('role:entity,cmd:save,zone:provider,base:github,name:repo',
       save_repo)
 
-    .message('role:entity,cmd:load,zone:provider,base:github,name:issue', issues_cmds.load_issue)
+    .message('role:entity,cmd:load,zone:provider,base:github,name:issue', commands.issue.load_issue)
 
   async function get_info(this: any, _msg: any) {
     return {
@@ -119,10 +110,8 @@ function GithubProvider(this: any, _options: any) {
       auth: out.value
     }
 
-    octokit = new Octokit(config)
-
-    commom_args.octokit = octokit
-    Object.freeze(commom_args)
+    octokit = initial_args.octokit = new Octokit(config)
+    Object.freeze(initial_args)
   })
 
 

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -117,6 +117,9 @@ function GithubProvider(this: any, _options: any) {
     }
 
     octokit = new Octokit(config)
+
+    initalArgs.octokit = octokit
+    Object.freeze(initalArgs)
   })
 
 

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -42,6 +42,7 @@ function GithubProvider(this: any, _options: any) {
       save_repo)
 
     .message('role:entity,cmd:load,zone:provider,base:github,name:issue', commands.issue.load_issue)
+    .message('role:entity,cmd:save,zone:provider,base:github,name:issue', commands.issue.save_issue)
 
   async function get_info(this: any, _msg: any) {
     return {

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -4,6 +4,7 @@
 // TODO: namespace provider zone; needs seneca-entity feature
 
 import { Octokit } from '@octokit/rest'
+import issues from './entities/issues'
 
 
 type GithubProviderOptions = {}
@@ -36,6 +37,8 @@ function GithubProvider(this: any, _options: any) {
   function initCmds(CommandsCb: any) {
     return CommandsCb(initalArgs)
   }
+
+  const issuesCmds = initCmds(issues)
 
   // NOTE: sys- zone prefix is reserved.
 

--- a/src/init-commands.ts
+++ b/src/init-commands.ts
@@ -1,5 +1,5 @@
-import issue from './entities/issue'
 import { InitialCommandsArgs } from './types'
+import issue from './entities/issue'
 
 /**
  * Passes initial arguments to the closure of each group of commands

--- a/src/init-commands.ts
+++ b/src/init-commands.ts
@@ -1,0 +1,15 @@
+import issue from './entities/issue'
+import { InitialCommandsArgs } from './types'
+
+/**
+ * Passes initial arguments to the closure of each group of commands
+ * @param initial_args object
+ * @returns {Object} object containing all commands of a entity
+ */
+function init_commands(initial_args: InitialCommandsArgs) {
+  return {
+    issue: issue(initial_args),
+  }
+}
+
+export default init_commands

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+import { Octokit } from "@octokit/rest";
+
+type InitialCommandsArgs = {
+  octokit: Octokit;
+  ZONE_BASE: string;
+};
+
+export type {
+  InitialCommandsArgs,
+}

--- a/test/entities/issues.test.ts
+++ b/test/entities/issues.test.ts
@@ -1,0 +1,74 @@
+/* Copyright © 2021 Seneca Project Contributors, MIT License. */
+
+import crypto from "crypto"
+
+import GithubProvider from "../../src/github-provider"
+
+const Seneca = require("seneca")
+const { provider_options } = require('../provider-options')
+
+describe('github-issues', () => {
+  // NOTE: provide a valid ownername/reponame
+  let repo_id = ''
+
+  if (!repo_id || repo_id.length === 0) {
+    throw new Error('invalid repo_id')
+  }
+
+  test("load-issue", async () => {
+    const seneca = Seneca({ legacy: false })
+      .test()
+      .use('promisify')
+      .use('entity')
+      .use('provider', provider_options)
+      .use(GithubProvider)
+      
+    const attrs = {
+      repo_id,
+      issue_number: 1
+    }
+
+    let entity = await seneca.entity('provider/github/issue').load$(attrs)
+
+    expect(entity.entity$).toBe('provider/github/issue')
+    expect(entity.id).toBeDefined()
+
+    // created attributes expectations
+    expect(entity.issue_number).toBe(attrs.issue_number)
+    expect(entity.repo_id).toBe(entity.repo_id)
+  })
+
+  test('save-issue', async () => {
+    const seneca = Seneca({ legacy: false })
+      .test()
+      .use('promisify')
+      .use('entity')
+      .use('provider', provider_options)
+      .use(GithubProvider)
+
+    const attrs = {
+      repo_id,
+      issue_number: 1
+    }
+
+    let entity = await seneca.entity('provider/github/issue').load$(attrs)
+
+    const randomBytes = crypto.randomBytes(10).toString('hex')
+
+    entity.title = randomBytes
+    entity.body = randomBytes
+
+    await entity.save$()
+
+    entity = await seneca.entity('provider/github/issue').load$(attrs)
+
+    expect(entity.entity$).toBe('provider/github/issue')
+    expect(entity.title).toBe(randomBytes)
+
+    // created attributes expectations
+    expect(entity.id).toBeDefined()
+    expect(entity.issue_number).toBe(attrs.issue_number)
+    expect(entity.repo_id).toBe(entity.repo_id)
+  })
+
+})

--- a/test/entities/issues.test.ts
+++ b/test/entities/issues.test.ts
@@ -11,10 +11,6 @@ describe('github-issues', () => {
   // NOTE: provide a valid ownername/reponame
   let repo_id = ''
 
-  if (!repo_id || repo_id.length === 0) {
-    throw new Error('invalid repo_id')
-  }
-
   test("load-issue", async () => {
     const seneca = Seneca({ legacy: false })
       .test()

--- a/test/github-provider.test.ts
+++ b/test/github-provider.test.ts
@@ -149,25 +149,5 @@ describe('github-provider', () => {
       expect(repo.description.endsWith('M')).toBeTruthy()
     }
   })
-
-  test('load-issue', async () => {
-    const seneca = Seneca({ legacy: false })
-      .test()
-      .use('promisify')
-      .use('entity')
-      .use('provider', provider_options)
-      .use(GithubProvider)
-      
-    const args = {
-      repo_id: 'senecajs/seneca-eventbrite-provider',
-      issue_number: 1
-    }
-
-    let entity = await seneca.entity('provider/github/issue').load$(args)
-
-    expect(entity.entity$).toBe('provider/github/issue')
-    expect(entity.repo_id).toBeDefined()
-    expect(entity.repo_id).toBe(args.repo_id)
-  })
 })
 

--- a/test/github-provider.test.ts
+++ b/test/github-provider.test.ts
@@ -16,6 +16,18 @@ if (Fs.existsSync(__dirname + '/local-config.js')) {
 
 describe('github-provider', () => {
 
+  let provider_options = {
+    provider: {
+      github: {
+        keys: {
+          api: {
+            value: CONFIG.key
+          }
+        }
+      }
+    }
+  }
+
   test('happy', async () => {
     const seneca = Seneca({ legacy: false })
       .test()
@@ -138,5 +150,24 @@ describe('github-provider', () => {
     }
   })
 
+  test('load-issue', async () => {
+    const seneca = Seneca({ legacy: false })
+      .test()
+      .use('promisify')
+      .use('entity')
+      .use('provider', provider_options)
+      .use(GithubProvider)
+      
+    const args = {
+      id: 'senecajs/seneca-eventbrite-provider',
+      issue_number: 1
+    }
+
+    let entity = await seneca.entity('provider/github/issue').load$(args)
+
+    expect(entity.entity$).toBe('provider/github/issue')
+    expect(entity.repo_id).toBeDefined()
+    expect(entity.repo_id).toBe(args.id)
+  })
 })
 

--- a/test/github-provider.test.ts
+++ b/test/github-provider.test.ts
@@ -159,7 +159,7 @@ describe('github-provider', () => {
       .use(GithubProvider)
       
     const args = {
-      id: 'senecajs/seneca-eventbrite-provider',
+      repo_id: 'senecajs/seneca-eventbrite-provider',
       issue_number: 1
     }
 
@@ -167,7 +167,7 @@ describe('github-provider', () => {
 
     expect(entity.entity$).toBe('provider/github/issue')
     expect(entity.repo_id).toBeDefined()
-    expect(entity.repo_id).toBe(args.id)
+    expect(entity.repo_id).toBe(args.repo_id)
   })
 })
 

--- a/test/provider-options.ts
+++ b/test/provider-options.ts
@@ -1,0 +1,21 @@
+import * as Fs from "fs"
+
+const CONFIG: any = {}
+
+if (Fs.existsSync(__dirname + '/local-config-template.js')) {
+  Object.assign(CONFIG, require(__dirname + '/local-config-template.js'))
+}
+
+const provider_options = {
+  provider: {
+    github: {
+      keys: {
+        api: {
+          value: CONFIG.key
+        }
+      }
+    }
+  }
+}
+
+export { provider_options }


### PR DESCRIPTION
This PR is to validate the approach on how concerns could be separated and how github entities should be handled in our domain (which attributes should they have).
 
 Changes:
 
- Creation of a function/closure for a group of actions related to Issues from Github API (and repeat it for each entity). Creation of a init_commands() to pass initial arguments to the closure of each group of commands

- I included repo_id into the Issue object after retrieving it from API, so that is possible to access owner and repo names when another entity method is called, subsequently (e.g save$(), remove$())

Every feedback is very welcome